### PR TITLE
support before-import hooks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,21 @@ Do things in your hook (``hooks.py``):
 After your profile (``my.package:default``) is installed, your hook is executed.
 
 
+Before-Import Hook
+------------------
+
+The standard hook (``profilehook:hook``) is executed *after* importing the profile.
+By using the ``profilehook:before_import_hook`` directive, you can register hooks
+which are executed *before* importing the profile.
+
+.. code:: xml
+
+  <profilehook:hook
+      profile="profilehook:before_import_hook"
+      handler=".hooks.before_installing_default_profile"
+      />
+
+
 
 Links
 =====

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support before-import hooks. [jone]
 
 
 1.0.0 (2014-08-15)

--- a/ftw/profilehook/configure.zcml
+++ b/ftw/profilehook/configure.zcml
@@ -10,4 +10,8 @@
       for="Products.GenericSetup.interfaces.IProfileImportedEvent"
       handler=".subscribers.profile_imported" />
 
+  <subscriber
+      for="Products.GenericSetup.interfaces.IBeforeProfileImportEvent"
+      handler=".subscribers.before_profile_import" />
+
 </configure>

--- a/ftw/profilehook/interfaces.py
+++ b/ftw/profilehook/interfaces.py
@@ -5,3 +5,9 @@ class IProfileHook(Interface):
 
     def __call__(site, install_context):
         pass
+
+
+class IBeforeImportHook(Interface):
+
+    def __call__(site, install_context):
+        pass

--- a/ftw/profilehook/meta.py
+++ b/ftw/profilehook/meta.py
@@ -1,3 +1,4 @@
+from ftw.profilehook.interfaces import IBeforeImportHook
 from ftw.profilehook.interfaces import IProfileHook
 from zope.component import zcml
 from zope.configuration.fields import GlobalObject
@@ -20,12 +21,28 @@ class IRegisterHook(Interface):
         required=True)
 
 
-def registerHook(_context, profile, handler):
+def register_hook(context, profile, handler):
+    return _register_hook_adapter(context,
+                                  profile=profile,
+                                  handler=handler,
+                                  directive_name='profilehook:hook',
+                                  providing=IProfileHook)
+
+
+def register_before_import_hook(context, profile, handler):
+    return _register_hook_adapter(context,
+                                  profile=profile,
+                                  handler=handler,
+                                  directive_name='profilehook:before_import_hook',
+                                  providing=IBeforeImportHook)
+
+
+def _register_hook_adapter(context, profile, handler, directive_name, providing):
     def factory(site):
         return handler
 
-    _context.action(
-        discriminator=('profile', profile),
+    context.action(
+        discriminator=(directive_name, profile),
         callable=zcml.handler,
         args=('registerAdapter',
-              factory, [Interface], IProfileHook, profile, _context.info))
+              factory, [Interface], providing, profile, context.info))

--- a/ftw/profilehook/meta.zcml
+++ b/ftw/profilehook/meta.zcml
@@ -6,7 +6,14 @@
         namespace="http://namespaces.zope.org/profilehook"
         name="hook"
         schema=".meta.IRegisterHook"
-        handler=".meta.registerHook"
+        handler=".meta.register_hook"
+        />
+
+    <meta:directive
+        namespace="http://namespaces.zope.org/profilehook"
+        name="before_import_hook"
+        schema=".meta.IRegisterHook"
+        handler=".meta.register_before_import_hook"
         />
 
 </configure>

--- a/ftw/profilehook/subscribers.py
+++ b/ftw/profilehook/subscribers.py
@@ -1,6 +1,8 @@
+from ftw.profilehook.interfaces import IBeforeImportHook
 from ftw.profilehook.interfaces import IProfileHook
 from Products.CMFCore.utils import getToolByName
 from zope.component import queryAdapter
+from zope.component.hooks import getSite
 import re
 
 
@@ -8,8 +10,19 @@ def profile_imported(event):
     if not event.full_import:
         return
 
-    profile = re.sub('^profile-', '', event.profile_id)
-    site = getToolByName(event.tool, 'portal_url').getPortalObject()
-    hook = queryAdapter(site, IProfileHook, name=profile)
+    trigger_hook_for(event.profile_id, IProfileHook)
+
+
+def before_profile_import(event):
+    if not event.full_import:
+        return
+
+    trigger_hook_for(event.profile_id, IBeforeImportHook)
+
+
+def trigger_hook_for(profile, providing):
+    profile = re.sub('^profile-', '', profile)
+    site = getToolByName(getSite(), 'portal_url').getPortalObject()
+    hook = queryAdapter(site, providing, name=profile)
     if hook:
         hook(site)

--- a/ftw/profilehook/tests/test_meta_directive.py
+++ b/ftw/profilehook/tests/test_meta_directive.py
@@ -1,7 +1,9 @@
+from ftw.profilehook.interfaces import IBeforeImportHook
 from ftw.profilehook.interfaces import IProfileHook
-from unittest2 import TestCase
 from ftw.profilehook.testing import PROFILEHOOK_INTEGRATION_TESTING
+from unittest2 import TestCase
 from zope.component import getAdapter
+from zope.component.interfaces import ComponentLookupError
 
 
 def hook(site):
@@ -29,4 +31,29 @@ class TestMetaDirective(TestCase):
 
         self.assertEquals(hook, getAdapter(self.layer['portal'],
                                            IProfileHook,
+                                           name='ftw.profilehook.tests:foo'))
+
+    def test_before_import_hook_registers_adapter(self):
+        self.layer['load_zcml_string'](
+            '<configure'
+            '   xmlns="http://namespaces.zope.org/zope"'
+            '   xmlns:five="http://namespaces.zope.org/five"'
+            '   xmlns:profilehook="http://namespaces.zope.org/profilehook">'
+
+            ' <include package="ftw.profilehook" />'
+            ' <profilehook:before_import_hook'
+            '     profile="ftw.profilehook.tests:foo"'
+            '     handler="{0}.hook"'
+            '     />'
+
+            '</configure>'.format(self.__module__))
+
+
+        with self.assertRaises(ComponentLookupError):
+            getAdapter(self.layer['portal'],
+                       IProfileHook,
+                       name='ftw.profilehook.tests:foo')
+
+        self.assertEquals(hook, getAdapter(self.layer['portal'],
+                                           IBeforeImportHook,
                                            name='ftw.profilehook.tests:foo'))


### PR DESCRIPTION
The new directive `profilehook:before_import_hook` allows to support hooks which are executed _before_ importing the profile.
