### PR TITLE
Fix compatibility with ftw.inflator.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix compatibility with ftw.inflator. [jone]
 
 
 1.2.0 (2016-05-11)

--- a/ftw/profilehook/subscribers.py
+++ b/ftw/profilehook/subscribers.py
@@ -1,6 +1,5 @@
 from ftw.profilehook.interfaces import IBeforeImportHook
 from ftw.profilehook.interfaces import IProfileHook
-from Products.CMFCore.utils import getToolByName
 from zope.component import queryAdapter
 from zope.component.hooks import getSite
 import re
@@ -22,7 +21,7 @@ def before_profile_import(event):
 
 def trigger_hook_for(profile, providing):
     profile = re.sub('^profile-', '', profile)
-    site = getToolByName(getSite(), 'portal_url').getPortalObject()
+    site = getSite()
     hook = queryAdapter(site, providing, name=profile)
     if hook:
         hook(site)


### PR DESCRIPTION
When using ftw.inflator and having ftw.profilehook installed, it will fail because we have events when we have no portal_url yet.

We actually do not require portal_url, we can just use the site directly.
