### PR TITLE
Fix error when uploading a tarball in portal_setup.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- Fix error when uploading a tarball in portal_setup. [jone]
 - Add plone 5.1.x test cfg. [mathias.leimgruber]
 
 

--- a/ftw/profilehook/subscribers.py
+++ b/ftw/profilehook/subscribers.py
@@ -9,11 +9,17 @@ def profile_imported(event):
     if not event.full_import:
         return
 
+    if not isinstance(event.profile_id, (str, unicode)):
+        return
+
     trigger_hook_for(event.profile_id, IProfileHook)
 
 
 def before_profile_import(event):
     if not event.full_import:
+        return
+
+    if not isinstance(event.profile_id, (str, unicode)):
         return
 
     trigger_hook_for(event.profile_id, IBeforeImportHook)


### PR DESCRIPTION
When manually uploading a tarball to portal_setup, it has no profile id. ftw.profilehook should ignore those tarballs.